### PR TITLE
Add ILS Indicators to HUD

### DIFF
--- a/B787-XE/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/HUD/B787_10_HUD.css
+++ b/B787-XE/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/HUD/B787_10_HUD.css
@@ -103,6 +103,15 @@ b787-10-hud-element {
         width: 25%;
         height: 100%;
         z-index: 0; }
+      b787-10-hud-element #MainFrame #InstrumentsContainer #ILS {
+         transform: rotateX(0);
+         position: absolute;
+         border: none;
+         top: 0%;
+         left: 0%;
+         width: 100%;
+         height: 100%;
+         z-index: 1; }
     b787-10-hud-element #MainFrame #FMAContainer {
       transform: rotateX(0);
       position: absolute;

--- a/B787-XE/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/HUD/B787_10_HUD.html
+++ b/B787-XE/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/HUD/B787_10_HUD.html
@@ -10,6 +10,7 @@
                 <jet-pfd-altimeter-indicator id="Altimeter"></jet-pfd-altimeter-indicator>
                 <jet-pfd-vspeed-indicator id="VSpeed"></jet-pfd-vspeed-indicator>
                 <jet-pfd-airspeed-indicator id="Airspeed"></jet-pfd-airspeed-indicator>
+                <jet-pfd-ils-indicator id="ILS"></jet-pfd-ils-indicator>
             </div>
             <div id="FMAContainer">
                 <boeing-fma id="FMA" class="AS01B_HUD"></boeing-fma>

--- a/B787-XE/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/HUD/B787_10_HUD.html
+++ b/B787-XE/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/HUD/B787_10_HUD.html
@@ -44,6 +44,7 @@
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/PFD/HSIndicator.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/PFD/AttitudeIndicator.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/PFD/VerticalSpeedIndicator.js"></script>
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/PFD/ILSIndicator.js"></script>
 
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/Shared/Boeing/Boeing_FMA.html"></script>
 

--- a/B787-XE/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/HUD/B787_10_HUD.js
+++ b/B787-XE/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/HUD/B787_10_HUD.js
@@ -44,7 +44,8 @@ class B787_10_HUD_MainPage extends NavSystemPage {
             new B787_10_HUD_Airspeed(),
             new B787_10_HUD_Altimeter(),
             new B787_10_HUD_NavStatus(),
-            this.compass
+            this.compass,
+            new B787_10_PFD_ILS()
         ]);
     }
     init() {
@@ -192,6 +193,32 @@ class B787_10_HUD_Compass extends NavSystemElement {
     onUpdate(_deltaTime) {
         if (this.svg) {
             this.svg.update(_deltaTime);
+        }
+    }
+    onExit() {
+    }
+    onEvent(_event) {
+    }
+}
+class B787_10_PFD_ILS extends NavSystemElement {
+    init(root) {
+        this.ils = this.gps.getChildById("ILS");
+        this.ils.aircraft = Aircraft.AS01B;
+        this.ils.gps = this.gps;
+        this.ils.showNavInfo(true);
+    }
+    onEnter() {
+    }
+    onUpdate(_deltaTime) {
+        if (this.ils) {
+            let showIls = false;
+            let localizer = this.gps.radioNav.getBestILSBeacon(false);
+            if (localizer.id != 0) {
+                showIls = true;
+            }
+            this.ils.showLocalizer(showIls);
+            this.ils.showGlideslope(showIls);
+            this.ils.update(_deltaTime);
         }
     }
     onExit() {


### PR DESCRIPTION
Since the HUD default is just a repeater of the PFD ADI, I copied code from PFD for ILS indicators to add them to the HUD.

![image](https://user-images.githubusercontent.com/12961704/93669480-70c90400-fa49-11ea-9b35-05f9d05960c6.png)
